### PR TITLE
Add an option for auto-reload in FastAPI server

### DIFF
--- a/debiai_data_provider/app.py
+++ b/debiai_data_provider/app.py
@@ -2,7 +2,7 @@ from debiai_data_provider.data_provider import DataProvider
 from debiai_data_provider.version import VERSION
 
 
-def start_api_server(data_provider: DataProvider, host, port):
+def start_api_server(data_provider: DataProvider, host, port, auto_reload=False):
     import uvicorn
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
@@ -26,4 +26,4 @@ def start_api_server(data_provider: DataProvider, host, port):
 
     app.include_router(controller_router)
 
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=host, port=port, reload=auto_reload)

--- a/debiai_data_provider/data_provider.py
+++ b/debiai_data_provider/data_provider.py
@@ -10,7 +10,7 @@ class DataProvider:
     def __init__(self):
         self.projects: List[ProjectToExpose] = []
 
-    def start_server(self, host="0.0.0.0", port=8000):
+    def start_server(self, host="0.0.0.0", port=8000, auto_reload=False):
         from debiai_data_provider.app import start_api_server
 
         # Print the server information
@@ -30,7 +30,7 @@ class DataProvider:
         for project in self.projects:
             console.print(project.get_rich_table())
 
-        start_api_server(self, host, port)
+        start_api_server(self, host, port, auto_reload)
 
     # Projects
     def add_project(

--- a/debiai_data_provider/models/project.py
+++ b/debiai_data_provider/models/project.py
@@ -144,7 +144,8 @@ class ProjectToExpose:
 
         if not isinstance(structure, dict):
             raise ValueError(
-                "The 'get_results_structure' method must return a dictionary."
+                f'The "get_results_structure" method must return a dictionary, got {type(structure)}.\n\
+Expected dictionary format: {{"col_name": {{"type": text, "group": text}}}}.'
             )
 
         structure = structure.copy()
@@ -178,7 +179,7 @@ class ProjectToExpose:
         # {
         #     "col_name": {
         #         "type": "text",
-        #         "group": "context",
+        #         "group": "text",
         #     },
         #     ...
         # }

--- a/debiai_data_provider/version.py
+++ b/debiai_data_provider/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.1"
+VERSION = "1.0.2"

--- a/examples/project_with_results.py
+++ b/examples/project_with_results.py
@@ -158,4 +158,4 @@ provider = DataProvider()
 provider.add_project(MyProjectWithResults())
 
 # Finally, start the server
-provider.start_server()
+provider.start_server(auto_reload=True)

--- a/examples/simple_project.py
+++ b/examples/simple_project.py
@@ -79,4 +79,4 @@ provider.add_project(MyProject())
 provider.add_project(MyProject2())
 
 # Finally, start the server
-provider.start_server()
+provider.start_server(auto_reload=True)


### PR DESCRIPTION
Fixes #4

Add auto-reload option to FastAPI server

* Add `auto_reload` parameter to `start_api_server` function in `debiai_data_provider/app.py` with a default value of `False`
* Update `uvicorn.run` method in `debiai_data_provider/app.py` to include `reload=auto_reload` argument
* Add `auto_reload` parameter to `start_server` method in `debiai_data_provider/data_provider.py` with a default value of `False`
* Pass `auto_reload` parameter to `start_api_server` function in `debiai_data_provider/data_provider.py`
* Update `provider.start_server` call in `examples/simple_project.py` to include `auto_reload=True`
* Update `provider.start_server` call in `examples/project_with_results.py` to include `auto_reload=True`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debiai/easy-data-provider/pull/5?shareId=9fa07d5b-481f-46f0-b091-eea835cbe944).